### PR TITLE
Change method name 'users' to 'getUserList'

### DIFF
--- a/62.Spring-Boot-Shiro-JWT/src/main/java/com/example/demo/utils/SystemUtils.java
+++ b/62.Spring-Boot-Shiro-JWT/src/main/java/com/example/demo/utils/SystemUtils.java
@@ -21,7 +21,7 @@ public class SystemUtils {
      *
      * @return List<User>
      */
-    private static List<User> users() {
+    private static List<User> getUserList() {
         List<User> users = new ArrayList<>();
         // 模拟两个用户：
         // 1. 用户名 admin，密码 123456，角色 admin（管理员），权限 "user:add"，"user:view"
@@ -46,7 +46,7 @@ public class SystemUtils {
      * @return 用户
      */
     public static User getUser(String username) {
-        List<User> users = SystemUtils.users();
+        List<User> users = SystemUtils.getUserList();
         return users.stream().filter(user -> StringUtils.equalsIgnoreCase(username, user.getUsername())).findFirst().orElse(null);
     }
 


### PR DESCRIPTION
This class is used to represent SystemUtils.  This method named 'users' is to get a list of users. Thus, the method name 'getUserList' is more intuitive than 'users'.